### PR TITLE
Fix deprecated optional dependency group name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 
 [project.optional-dependencies]
 
-depricated = [
+deprecated = [
     "bigstream @ file:///archive/bioinformatics/Danuser_lab/Dean/dean/git/bigstream",
 ]
 


### PR DESCRIPTION
## Summary
- rename `depricated` optional dependency group to `deprecated`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ants')*

------
https://chatgpt.com/codex/tasks/task_e_683d10ee29dc8325a811e2b916d49691