### PR TITLE
Add ClearEx CLI entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,23 @@
 [![codecov](https://codecov.io/gh/TheDeanLab/clearex/graph/badge.svg?token=ONldpMpLse)](https://codecov.io/gh/TheDeanLab/clearex)
 
 **ClearEx** is an open source Python package for scalable analytics of cleared and expanded tissue imaging data. It relies heavily on next-generation file formats and cloud-based chunk computing to accelerate image analysis workflows, enabling tissue-scale computer vision and machine learning.
+
+## Installation
+
+We recommend installing ClearEx in a dedicated Anaconda environment:
+
+```bash
+conda create -n clearex python=3.11
+conda activate clearex
+pip install clearex
+```
+
+## Launching the CLI
+
+Once installed and the environment is active, start the ClearEx command line interface by running:
+
+```bash
+clearex
+```
+
+Follow the prompts to perform image registration.

--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@
 We recommend installing ClearEx in a dedicated Anaconda environment:
 
 ```bash
-conda create -n clearex python=3.11
+conda create -n clearex python=3.12
 conda activate clearex
-pip install clearex
+cd to/your/cloned/clearex/directory
+pip install -e .
 ```
 
 ## Launching the CLI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,3 +60,6 @@ docs = [
 
 [project.urls]
 Source = "https://github.com/TheDeanLab/clearex"
+
+[project.scripts]
+clearex = "clearex.main:app"

--- a/src/clearex/main.py
+++ b/src/clearex/main.py
@@ -1,0 +1,44 @@
+import typer
+
+app = typer.Typer(help="Command line interface for ClearEx")
+
+CLEAR_EX_LOGO = r"""
+ ░▒▓██████▓▒░░▒▓█▓▒░      ░▒▓████████▓▒░░▒▓██████▓▒░░▒▓███████▓▒░░▒▓████████▓▒░▒▓█▓▒░░▒▓█▓▒░ 
+░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░      ░▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░ 
+░▒▓█▓▒░      ░▒▓█▓▒░      ░▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░ 
+░▒▓█▓▒░      ░▒▓█▓▒░      ░▒▓██████▓▒░ ░▒▓████████▓▒░▒▓███████▓▒░░▒▓██████▓▒░  ░▒▓██████▓▒░  
+░▒▓█▓▒░      ░▒▓█▓▒░      ░▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░ 
+░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░      ░▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░ 
+ ░▒▓██████▓▒░░▒▓████████▓▒░▒▓████████▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓████████▓▒░▒▓█▓▒░░▒▓█▓▒░ 
+"""
+
+@app.command()
+def main():
+    """Run the ClearEx command line interface."""
+    typer.echo(CLEAR_EX_LOGO)
+    typer.echo("Welcome to ClearEx!")
+
+    operation = typer.prompt(
+        "What type of image operation would you like to perform?",
+        default="registration",
+    )
+
+    if operation.lower() != "registration":
+        typer.echo("Only the registration routine is currently available.")
+        raise typer.Exit(code=1)
+
+    reference = typer.prompt("Reference image location")
+    moving = typer.prompt("Image to register")
+    output = typer.prompt("Location to save the data")
+
+    typer.echo("Starting registration...")
+    # Placeholder for future registration call
+    typer.echo(f"Reference: {reference}")
+    typer.echo(f"Moving: {moving}")
+    typer.echo(f"Output directory: {output}")
+
+    typer.echo("Done.")
+
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
## Summary
- provide a command line interface under `src/clearex/main.py`
- show a ClearEx ASCII logo and prompt for registration info
- expose CLI as the `clearex` shell command via project scripts
- update README with conda install directions and CLI usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683d93c0d5008325ab1e39bdd03f13bb