### PR TITLE
Fix logger setup to remove NullHandlers

### DIFF
--- a/src/clearex/__init__.py
+++ b/src/clearex/__init__.py
@@ -60,6 +60,11 @@ def setup_logger(name='my_logger', log_file='app.log', level=logging.INFO):
     logger = logging.getLogger(name)
     logger.setLevel(level)
 
+    # Remove any NullHandlers that may have been added by other modules
+    for handler in list(logger.handlers):
+        if isinstance(handler, logging.NullHandler):
+            logger.removeHandler(handler)
+
     # Prevent duplicate handlers if logger already exists
     if not logger.handlers:
         logger.addHandler(file_handler)


### PR DESCRIPTION
## Summary
- remove any `NullHandler` handlers from loggers in `setup_logger`
- keep check for existing handlers before adding file/console handlers

## Testing
- `pytest -q`
- manual logging check using `setup_logger`

------
https://chatgpt.com/codex/tasks/task_e_684c342e0adc8325ba1f6f8295497ce3