### PR TITLE
Update workflow to use uv

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,10 +23,22 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install uv
+        run: |
+          curl -Ls https://astral.sh/uv/install.sh | sh
+
+      - name: Cache uv
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-${{ hashFiles('**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
+
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e '.[dev]'
+          uv pip install -e '.[dev]'
 
       - name: Run Tests
         run: |


### PR DESCRIPTION
## Summary
- install `uv` in CI and cache its directory
- use `uv pip install` for dev dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c3c99f5988325b3c45c1ba3b55e52