### PR TITLE
[codex] Fix main CI regressions in GUI import fallbacks and docs build

### DIFF
--- a/docs/source/runtime/cli-and-execution.rst
+++ b/docs/source/runtime/cli-and-execution.rst
@@ -266,26 +266,25 @@ ClearEx now separates movie generation into two explicit operations:
 
 Runtime storage:
 
-- ``render_movie`` latest metadata:
-  - ``clearex/results/render_movie/latest``
-- ``compile_movie`` latest metadata:
-  - ``clearex/results/compile_movie/latest``
-- Default in-store artifacts:
-  - ``<analysis_store>/clearex/results/visualization/latest/keyframes.json``
-  - ``<analysis_store>/clearex/results/render_movie/latest/render_manifest.json``
-  - ``<analysis_store>/clearex/results/render_movie/latest/level_<nn>_frames/frame_000000.png``
-  - ``<analysis_store>/clearex/results/compile_movie/latest/*.mp4``
-  - ``<analysis_store>/clearex/results/compile_movie/latest/*.mov``
-- Override note:
-  - ``output_directory`` can still redirect ``render_movie`` or
-    ``compile_movie`` to an external export tree when desired.
+- ``render_movie`` latest metadata lives under
+  ``clearex/results/render_movie/latest``.
+- ``compile_movie`` latest metadata lives under
+  ``clearex/results/compile_movie/latest``.
+- Default in-store artifacts include
+  ``<analysis_store>/clearex/results/visualization/latest/keyframes.json``,
+  ``<analysis_store>/clearex/results/render_movie/latest/render_manifest.json``,
+  ``<analysis_store>/clearex/results/render_movie/latest/level_<nn>_frames/frame_000000.png``,
+  ``<analysis_store>/clearex/results/compile_movie/latest/*.mp4``, and
+  ``<analysis_store>/clearex/results/compile_movie/latest/*.mov``.
+- ``output_directory`` can still redirect ``render_movie`` or
+  ``compile_movie`` to an external export tree when desired.
 
 Practical guidance:
 
 - Use coarse levels such as ``[1]`` or ``[2]`` plus moderate frame sizes for
   preview renders.
 - Use level ``0`` and the final frame size for publication renders.
-- `default_transition_frames` around ``48`` is a good default for smooth
+- ``default_transition_frames`` around ``48`` is a good default for smooth
   motion.
 - ``mp4_crf`` in the ``16`` to ``24`` range is a reasonable review/final
   quality band, with lower values trading size for quality.

--- a/src/clearex/gui/app.py
+++ b/src/clearex/gui/app.py
@@ -246,6 +246,38 @@ def _resolve_gui_asset_path(filename: str) -> Path:
     return (_GUI_ASSET_DIRECTORY / filename).resolve()
 
 
+def _apply_application_icon(app: Any) -> None:
+    """Fallback no-op when PyQt6 is unavailable at import time.
+
+    Parameters
+    ----------
+    app : Any
+        Placeholder application object.
+
+    Returns
+    -------
+    None
+        No-op fallback used until the PyQt implementation overrides it.
+    """
+    del app
+
+
+def _show_startup_splash(app: Any) -> None:
+    """Fallback no-op when PyQt6 is unavailable at import time.
+
+    Parameters
+    ----------
+    app : Any
+        Placeholder application object.
+
+    Returns
+    -------
+    None
+        No-op fallback used until the PyQt implementation overrides it.
+    """
+    del app
+
+
 def _primary_screen_available_size() -> Optional[tuple[int, int]]:
     """Return the available size of the primary screen for the active app.
 

--- a/tests/gui/test_gui_execution.py
+++ b/tests/gui/test_gui_execution.py
@@ -4,7 +4,10 @@
 from __future__ import annotations
 
 import inspect
+import json
 import math
+import subprocess
+import sys
 import threading
 from pathlib import Path
 from types import SimpleNamespace
@@ -257,6 +260,51 @@ def test_resolve_initial_dialog_dimensions_keeps_larger_default_size() -> None:
 
     assert minimum_size == app_module._SETUP_DIALOG_MINIMUM_SIZE
     assert startup_size == app_module._SETUP_DIALOG_PREFERRED_SIZE
+
+
+def test_gui_module_exports_fallback_helpers_when_pyqt6_is_unavailable() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    script = f"""
+import builtins
+import importlib
+import json
+import sys
+
+sys.path.insert(0, {str(repo_root / "src")!r})
+original_import = builtins.__import__
+
+
+def _blocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+    if name == "PyQt6" or name.startswith("PyQt6."):
+        raise ImportError("blocked for test")
+    return original_import(name, globals, locals, fromlist, level)
+
+
+builtins.__import__ = _blocked_import
+module = importlib.import_module("clearex.gui.app")
+print(
+    json.dumps(
+        {{
+            "HAS_PYQT6": module.HAS_PYQT6,
+            "has_apply_application_icon": hasattr(module, "_apply_application_icon"),
+            "has_show_startup_splash": hasattr(module, "_show_startup_splash"),
+        }}
+    )
+)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+    )
+
+    assert json.loads(result.stdout) == {
+        "HAS_PYQT6": False,
+        "has_apply_application_icon": True,
+        "has_show_startup_splash": True,
+    }
 
 
 def test_resolve_initial_dialog_dimensions_clamps_to_available_screen() -> None:

--- a/tests/io/test_experiment.py
+++ b/tests/io/test_experiment.py
@@ -353,7 +353,10 @@ def test_create_dask_client_gpu_worker_env_merges_inherited_library_path(
         "_detect_cuda_library_paths",
         lambda: ["/cuda/runtime/lib", "/cuda/cudnn/lib"],
     )
-    path_env_var = experiment_module._library_path_env_vars_for_platform()[0]
+    path_env_vars = experiment_module._library_path_env_vars_for_platform()
+    for env_var in path_env_vars:
+        monkeypatch.delenv(env_var, raising=False)
+    path_env_var = path_env_vars[0]
     monkeypatch.setenv(path_env_var, "/cluster/custom/lib")
 
     _ = experiment_module.create_dask_client(


### PR DESCRIPTION
## Summary
This PR fixes the red `main` CI state in both the `Tests` and `Docs` workflows.

The main test regression came from `clearex.gui.app` exposing `_apply_application_icon` and `_show_startup_splash` only when `PyQt6` imported successfully at module import time. On GitHub Actions, the module could be imported in a `PyQt6`-unavailable state, which left those helpers undefined and caused GUI tests that monkeypatch them to fail.

The docs regression came from malformed nested list indentation in the movie runtime-storage section of the runtime docs, which caused the Sphinx build to fail with `Unexpected indentation`.

## What Changed
- Added import-safe no-op fallbacks for `_apply_application_icon` and `_show_startup_splash` in `clearex.gui.app`, with the existing PyQt implementations still overriding them when PyQt6 is available.
- Added a regression test that imports `clearex.gui.app` with `PyQt6` deliberately blocked and asserts that the fallback helper surface still exists.
- Rewrote the movie runtime-storage bullets in the runtime docs to valid reStructuredText and normalized one inline literal for `default_transition_frames`.
- Hardened the Dask GPU worker environment test by clearing inherited platform library-path variables before asserting the merged value, so host-specific environment state does not create false negatives.

## Impact
- Restores the GUI helper surface expected by the CI GUI tests even when PyQt-dependent code paths are unavailable at import time.
- Restores a passing Sphinx docs build on `main`.
- Makes the full local pytest run less sensitive to machine-specific library path state.

## Validation
- `uv run pytest -q tests/gui/test_gui_execution.py`
- `uv run python -m sphinx -W --keep-going -b html docs/source docs/_build/html`
- `uv run ruff check src/clearex/gui/app.py tests/gui/test_gui_execution.py tests/io/test_experiment.py`
- `uv run pytest -m "not biohpc" --cov=./ --cov-report=xml`
